### PR TITLE
set: Use bound `hasOwnProperty`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "url": "https://github.com/isaacs/proto-list"
   },
   "license": "ISC",
+  "dependencies": {
+    "has": "^1.0.3"
+  },
   "devDependencies": {
     "tap": "^1.2.0"
   }

--- a/proto-list.js
+++ b/proto-list.js
@@ -1,3 +1,4 @@
+var hasOwn = require("has")
 
 module.exports = ProtoList
 
@@ -68,7 +69,7 @@ ProtoList.prototype =
     }
   , set : function (key, val, save) {
       if (!this.length) this.push({})
-      if (save && this.list[0].hasOwnProperty(key)) this.push({})
+      if (save && hasOwn(this.list[0], key)) this.unshift({})
       return this.list[0][key] = val
     }
   , forEach : function (fn, thisp) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -57,5 +57,13 @@ tap.test("protoList tests", function (t) {
     p.shift()
   }
 
+  p = new ProtoList
+  p.root = null
+  p.push({})
+  t.equal(p.get('hasOwnProperty'), undefined, 'new ProtoList.list[0] does not inherit from Object.prototype')
+  t.doesNotThrow(function () {
+    p.set('foo', 'bar', true)
+  }, 'p.set does not throw when `save` is `true` and `p.list[0]` does not inherit from Object.prototype')
+
   t.end()
 })


### PR DESCRIPTION
The tiny **npm** package [`has`](https://www.npmjs.com/package/has) exports a `Function.prototype.call.bind(Object.prototype.hasOwnProperty)` helper, which has the advantage of working when `p.root === null` or `p.hasOwnProperty` is not the `Object.prototype.hasOwnProperty` function.